### PR TITLE
refactor: Stop the scripts from copying on top of themselves from nod…

### DIFF
--- a/npm_scripts/ci.js
+++ b/npm_scripts/ci.js
@@ -1,5 +1,4 @@
 const exec = require('./exec');
 
-exec(`npm run copy-utils`);
 exec(`npm test`);
 exec(`npm run build`);

--- a/npm_scripts/dev-setup.js
+++ b/npm_scripts/dev-setup.js
@@ -2,8 +2,6 @@ const path = require('path');
 const exec = require('./exec');
 const fs = require('fs-extra');
 
-exec(`npm run copy-utils`);
-
 try {
   fs.copySync(path.join(__dirname, '..', 'node_modules/pearson-elements/dist/fonts'), path.join(__dirname, '..', 'fonts'));
 } catch (err) {

--- a/npm_scripts/pretest.js
+++ b/npm_scripts/pretest.js
@@ -1,4 +1,3 @@
 const exec = require('./exec');
 
-exec(`npm run copy-utils`);
 exec(`npm run lint`);

--- a/npm_scripts/release.js
+++ b/npm_scripts/release.js
@@ -30,11 +30,6 @@ if (branchName !== 'master') {
   exitFailure('You must be on the master branch in order to execute a release.');
 }
 
-// Ensure scripts have been copied, if being executed by another component
-if (`${pkg.name}` !== '@pearson-components/npm-scripts') {
-  exec(`npm run copy-utils`);
-}
-
 // Ensure unit tests pass before continuing!
 exec('npm test');
 

--- a/npm_scripts/version.js
+++ b/npm_scripts/version.js
@@ -1,5 +1,4 @@
 const exec = require('./exec');
 
-exec(`npm run copy-utils`);
 exec(`npm run gen-changelog`);
 exec(`git add CHANGELOG.md`);


### PR DESCRIPTION
…e_modules while executing from the archetype's npm_scripts.