### PR TITLE
fix: release script detects parent package.json

### DIFF
--- a/npm_scripts/release.js
+++ b/npm_scripts/release.js
@@ -5,9 +5,10 @@ const exec = require('./exec');
 const path = require('path');
 const readline = require('readline');
 const semver = require('semver');
-const pkg = require('../package.json');
+const parentPkg = require('../../../../package.json');
+const copiedPkg = require('../package.json');
 const branchName = exec('git rev-parse --abbrev-ref HEAD', true);
-const currentVersion = pkg.version;
+const currentVersion = (parentPkg) ? parentPkg.version : copiedPkg.version;
 const stdin = readline.createInterface({
   input: process.stdin,
   output: process.stdout


### PR DESCRIPTION
this fixes compounds release.... the problem was that compounds dosen't copy scripts to parent level.... instead it references them in the node_modules....  this led to the npm_scripts package.json version being read instead of the parent applications.... this looks for a parent and if it exists then use that otherwise use the local package.