### PR TITLE
fix: this should fix the problems of the script failing due to conflicts

### DIFF
--- a/npm_scripts/gh-pages.js
+++ b/npm_scripts/gh-pages.js
@@ -48,7 +48,7 @@ try {
 
  exec('git add build');
  exec('git commit -am "chore: gh-pages comment out build"');
- exec('git subtree push --prefix build origin gh-pages');
+ exec('git subtree push -f --prefix build origin gh-pages');
 
 } catch (err) {
    console.log("error commiting to gh-pages... skipping");


### PR DESCRIPTION
when the script is run there is a conflict that occrues on push that keeps the script from completing I had been running: 

git push origin :gh-pages    <------ wipe out the gh-pages branch due to conflicts
npm run gh-pages               <------  run the script after doing a fresh pull of the branch to publish.

this causes a good amount of downtime....

so, i made the subtree push a force push to try and get around the 404's...  if the force push doesn't work out for some reason we'll have to insert that `git push origin :gh-pages` just before the git subtree push in the gh-pages script.